### PR TITLE
only parse keys that exist

### DIFF
--- a/taraxa/taraxa/methods.py
+++ b/taraxa/taraxa/methods.py
@@ -4,7 +4,8 @@ from ..jsonrpc.http_taraxa import *
 def dag_block_hex2int(block):
     keys = ['level', 'period', 'number', 'timestamp']
     for key in keys:
-        block[key] = hex2int(block[key])
+        if block[key]:
+            block[key] = hex2int(block[key])
     return block
 
 


### PR DESCRIPTION
This fixes an issue in the explorer API when not getting the key 'number'